### PR TITLE
Use openJdk instead of Oracle for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-    - oraclejdk8
+    - openjdk8


### PR DESCRIPTION
The Travis build is failing when using Oracle JDK 8. This changes the build to use Open JDK 8 for the build instead.