### PR TITLE
Deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,12 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 
+# Visual studio
+/.vs/*
+
+# Visual studio code
+/.vscode/*
+
 **/target/
 **/bin/
 *.iml

--- a/.maven.xml
+++ b/.maven.xml
@@ -1,0 +1,24 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0" xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- For automating the maven release using Travis. See: https://www.phillip-kruger.com/post/continuous_integration_to_maven_ce -->
+  <servers>
+    <server>
+      <!-- Maven Central Deployment -->
+      <id>ossrh</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ before_deploy:
   #
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
   - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
-  #
-  # Tag the build
-  #
-  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
 
 deploy:
   #
@@ -27,12 +23,10 @@ deploy:
     secure: QRDWEzr7ecy99uFYetCl6v0t1QSJKfAUJcMPxWQJNWohmzO1oxA7SJF+1PUqyj8cgP+ykZDrqdI3jHZCU+YPOtXirxDkxItc/uMsfJBQAaMlDLzIiZpx6husPAzvatp7xDC/KSRKfQlTv7NnP9oLt/hn8phTxHGyIssV6Xnpd/e84Uqu55NxyeuIfuTeEoVzuC8o4c5NpAClYASwgHV4l8e8uTDQqITx2Y/qbsukh/bq0TYLAQZkHf9GzhJ9Kfqo6p4vMybzn9bGUptf1c/gIUb/OckBTDC4yka3xHdTWvk+nlKPTPrO4LEeIrJ2JbT46ljBqaRzXmAEjr7A2l2rJd3xMOgD09Cb1Od+xiQ900hrh2o/0oSjcChRLZbRe/ztpe5SmJuyJcesBMM+wlvwwNE6hVc77BBCKvzen88OXHzgB8VX3ymKgz6adFKgNI614nemLcNP8/UyqqnjMf5rfknTp9rOkIxmmt9LNSapABCs2IJRlx5zQBup6ij3S66TL5JogEHsVxEzm1zn3vFOx2FJA+tRbd414eP0iB87Zi9tzI9z2/ZBkHTEUXnn22Y0w6W2fPJznTJ4NyJGMmgNLVvpmq0sl9KpfGp4rkof/kADhfxTIjUjRzc1UDHkiJHzxG/Tbw1Ojo+rQnj1RsestQ586tVvGOg0zhiapikGCOE=
   file: gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
   on:
-    #tags: true
     repo: gettyimages/gettyimages-api_java
     # TODO remove the branch after you're done testing
     branch: deploy
-  # TODO is this the name we want?
   name: $project_version
-  # TODO: set draft to false after you're done testing
-  draft: true
+  # set draft to true for testing
+  draft: false
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,34 @@
 language: java
 jdk:
-    - openjdk8
+- openjdk8
+
+before_deploy:
+  #
+  # Read the project version 
+  #
+  - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
+  - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
+
+deploy:
+  #
+  # Release instructions
+  # if you need to change the api key 
+  #   * install the travis client on your local machine (you will need Ruby installed)
+  #       ** gem install travis
+  #   * in the directory containing this yml file run the following command and follow the prompts
+  #       ** travis setup releases
+  #
+  provider: releases
+  api_key:
+    secure: QRDWEzr7ecy99uFYetCl6v0t1QSJKfAUJcMPxWQJNWohmzO1oxA7SJF+1PUqyj8cgP+ykZDrqdI3jHZCU+YPOtXirxDkxItc/uMsfJBQAaMlDLzIiZpx6husPAzvatp7xDC/KSRKfQlTv7NnP9oLt/hn8phTxHGyIssV6Xnpd/e84Uqu55NxyeuIfuTeEoVzuC8o4c5NpAClYASwgHV4l8e8uTDQqITx2Y/qbsukh/bq0TYLAQZkHf9GzhJ9Kfqo6p4vMybzn9bGUptf1c/gIUb/OckBTDC4yka3xHdTWvk+nlKPTPrO4LEeIrJ2JbT46ljBqaRzXmAEjr7A2l2rJd3xMOgD09Cb1Od+xiQ900hrh2o/0oSjcChRLZbRe/ztpe5SmJuyJcesBMM+wlvwwNE6hVc77BBCKvzen88OXHzgB8VX3ymKgz6adFKgNI614nemLcNP8/UyqqnjMf5rfknTp9rOkIxmmt9LNSapABCs2IJRlx5zQBup6ij3S66TL5JogEHsVxEzm1zn3vFOx2FJA+tRbd414eP0iB87Zi9tzI9z2/ZBkHTEUXnn22Y0w6W2fPJznTJ4NyJGMmgNLVvpmq0sl9KpfGp4rkof/kADhfxTIjUjRzc1UDHkiJHzxG/Tbw1Ojo+rQnj1RsestQ586tVvGOg0zhiapikGCOE=
+  file: gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
+  on:
+    tags: true
+    repo: gettyimages/gettyimages-api_java
+    # TODO remove the branch after you're done testing
+    branch: deploy
+    # TODO is this the name we want?
+  name: $project_version
+  # TODO: set draft to false after you're done testing
+  draft: true
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,39 @@
 language: java
-jdk:
-- openjdk8
+jdk: # jdk versions to test against - https://www.deps.co/guides/travis-ci-latest-java/
+- openjdk8 # oldest version we support. Do not use Oracle because the license expires.
+- openjdk11 # most recent version supported by Travis
+- openjdk-ea # early release - allow failures, but be aware that there *are* errors
+
+matrix:
+  allow_failures: # https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail
+    - jdk: openjdk-ea # allow early access version to fail
 
 before_deploy:
-  #
-  # Read the project version 
-  #
+  # Begin Extract the project version
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
   - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
-  #
-  # Tag the build
-  #
-  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  # End Extract
 
 deploy:
+  draft: true # set draft to true for testing - creates a build accessible only by collaborators
+  name: $project_version # use the project version extracted in before_deploy as the name
+  skip_cleanup: true # don't cleanup - we need the artifacts for deploying
+
+  on:
+    repo: gettyimages/gettyimages-api_java
+    tags: true # only build tagged commits
+
+  file: 
+    - gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
+    
+  provider: releases # https://docs.travis-ci.com/user/deployment/releases
   #
-  # Release instructions
+  # Releases instructions
   # if you need to change the api key 
   #   * install the travis client on your local machine (you will need Ruby installed)
   #       ** gem install travis
   #   * in the directory containing this yml file run the following command and follow the prompts
   #       ** travis setup releases
   #
-  provider: releases
   api_key:
     secure: QRDWEzr7ecy99uFYetCl6v0t1QSJKfAUJcMPxWQJNWohmzO1oxA7SJF+1PUqyj8cgP+ykZDrqdI3jHZCU+YPOtXirxDkxItc/uMsfJBQAaMlDLzIiZpx6husPAzvatp7xDC/KSRKfQlTv7NnP9oLt/hn8phTxHGyIssV6Xnpd/e84Uqu55NxyeuIfuTeEoVzuC8o4c5NpAClYASwgHV4l8e8uTDQqITx2Y/qbsukh/bq0TYLAQZkHf9GzhJ9Kfqo6p4vMybzn9bGUptf1c/gIUb/OckBTDC4yka3xHdTWvk+nlKPTPrO4LEeIrJ2JbT46ljBqaRzXmAEjr7A2l2rJd3xMOgD09Cb1Od+xiQ900hrh2o/0oSjcChRLZbRe/ztpe5SmJuyJcesBMM+wlvwwNE6hVc77BBCKvzen88OXHzgB8VX3ymKgz6adFKgNI614nemLcNP8/UyqqnjMf5rfknTp9rOkIxmmt9LNSapABCs2IJRlx5zQBup6ij3S66TL5JogEHsVxEzm1zn3vFOx2FJA+tRbd414eP0iB87Zi9tzI9z2/ZBkHTEUXnn22Y0w6W2fPJznTJ4NyJGMmgNLVvpmq0sl9KpfGp4rkof/kADhfxTIjUjRzc1UDHkiJHzxG/Tbw1Ojo+rQnj1RsestQ586tVvGOg0zhiapikGCOE=
-  file: gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
-  on:
-    repo: gettyimages/gettyimages-api_java
-    # TODO remove the branch after you're done testing
-    branch: deploy
-  name: $project_version
-  # set draft to true for testing
-  draft: false
-  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_deploy:
   # End Extract
 
 deploy:
-  draft: true # set draft to true for testing - creates a build accessible only by collaborators
+  draft: false # set draft to true for testing - creates a draft build accessible only by collaborators
   name: $project_version # use the project version extracted in before_deploy as the name
   skip_cleanup: true # don't cleanup - we need the artifacts for deploying
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   ## Build and release to maven central
-  mvn clean deploy --settings .maven.xml -DskipTests=true -B -U -prepare_release
+  mvn clean deploy --settings .maven.xml -DskipTests=true -B -U -P prepare_release
 
 before_deploy:
   # Begin Extract the project version

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,11 @@ deploy:
     repo: gettyimages/gettyimages-api_java
     tags: true # only build tagged commits
 
-  file: 
+  file:
     - gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
-    
+
+
   provider: releases # https://docs.travis-ci.com/user/deployment/releases
-  #
-  # Releases instructions
-  # if you need to change the api key 
-  #   * install the travis client on your local machine (you will need Ruby installed)
-  #       ** gem install travis
-  #   * in the directory containing this yml file run the following command and follow the prompts
-  #       ** travis setup releases
-  #
-  api_key:
-    secure: QRDWEzr7ecy99uFYetCl6v0t1QSJKfAUJcMPxWQJNWohmzO1oxA7SJF+1PUqyj8cgP+ykZDrqdI3jHZCU+YPOtXirxDkxItc/uMsfJBQAaMlDLzIiZpx6husPAzvatp7xDC/KSRKfQlTv7NnP9oLt/hn8phTxHGyIssV6Xnpd/e84Uqu55NxyeuIfuTeEoVzuC8o4c5NpAClYASwgHV4l8e8uTDQqITx2Y/qbsukh/bq0TYLAQZkHf9GzhJ9Kfqo6p4vMybzn9bGUptf1c/gIUb/OckBTDC4yka3xHdTWvk+nlKPTPrO4LEeIrJ2JbT46ljBqaRzXmAEjr7A2l2rJd3xMOgD09Cb1Od+xiQ900hrh2o/0oSjcChRLZbRe/ztpe5SmJuyJcesBMM+wlvwwNE6hVc77BBCKvzen88OXHzgB8VX3ymKgz6adFKgNI614nemLcNP8/UyqqnjMf5rfknTp9rOkIxmmt9LNSapABCs2IJRlx5zQBup6ij3S66TL5JogEHsVxEzm1zn3vFOx2FJA+tRbd414eP0iB87Zi9tzI9z2/ZBkHTEUXnn22Y0w6W2fPJznTJ4NyJGMmgNLVvpmq0sl9KpfGp4rkof/kADhfxTIjUjRzc1UDHkiJHzxG/Tbw1Ojo+rQnj1RsestQ586tVvGOg0zhiapikGCOE=
+
+# GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in the GitHub repository
+  api_key: GITHUB_PERSONAL_ACCESS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,8 @@ deploy:
 
   provider: releases # https://docs.travis-ci.com/user/deployment/releases
 
-# GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in the GitHub repository
-  api_key: GITHUB_PERSONAL_ACCESS_TOKEN
+# GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in Travis-CI
+# https://travis-ci.org/gettyimages/gettyimages-api_java/settings
+# It must be enabled for the branch you're working on.
+  api_key: 
+    secure: GITHUB_PERSONAL_ACCESS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ before_deploy:
   #
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
   - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
+  #
+  # Tag the build
+  #
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
 
 deploy:
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ before_deploy:
   #
   - mvn help:evaluate -N -Dexpression=project.version|grep -v '\['
   - export project_version=$(mvn help:evaluate -N -Dexpression=project.version|grep -v '\[')
+  #
+  # Tag the build
+  #
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
 
 deploy:
   #
@@ -27,7 +31,7 @@ deploy:
     repo: gettyimages/gettyimages-api_java
     # TODO remove the branch after you're done testing
     branch: deploy
-    # TODO is this the name we want?
+  # TODO is this the name we want?
   name: $project_version
   # TODO: set draft to false after you're done testing
   draft: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: java
 jdk: # jdk versions to test against - https://www.deps.co/guides/travis-ci-latest-java/
      # Open JDK support: https://adoptopenjdk.net/support.html
 - openjdk8 # LTS through at least 2023.09
-- openjdk11 # LTS through at least 2022.09
-- openjdk-ea # early release - allow failures, but be aware that there *are* errors
+# It would be nice to test these, but multiple tests mean that Travis will do multiple
+# deploys, only one of which would succeed.
+#- openjdk11 # LTS through at least 2022.09
+#- openjdk-ea # early release - allow failures, but be aware that there *are* errors
 
 matrix:
   allow_failures: # https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail
@@ -45,7 +47,6 @@ deploy:
 # GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in Travis-CI
 # https://travis-ci.org/gettyimages/gettyimages-api_java/settings
 # https://stackoverflow.com/questions/33735992/travis-ci-using-repository-environment-variables-in-travis-yml
-# It must be enabled for the branch you're working on.
-  #api_key: GITHUB_PERSONAL_ACCESS_TOKEN
+# It must be enabled for the branch you're working on. NOTE: you can't use an environment variable because they're not set here.
   api_key:
     secure: pJkTcxWJUO0eJK6fH5D7Vb3BEQoc9tnKGX5pTa7n6OCqJU3qQHJVVpAphoCW5BfYQl1A7svNYGNZh7l/quzznxhBLS1HoV78AJcM4PnL1L/WuSgSIHDwOUZpZ1xctqMcZFh1+oavR4tRTk/mvcjBmUrcR1nOgctdx19i5/FzN7AlVwQZDZi80pd1Q/XnK0ID71GDQ0Zrb0w3Txi4/xHgsDbkN6By0wdCKd3slnYX6Bdd3zLSSGYmqdWWHMUgWrU8yMXwAP5G0lgksNBKv71JxBx6ZJE0QOeqvbIeIn9zLbRxHQKgbw9gJBeXHmlQBcbE+yJ5SqAfuPguSWQRs9PbCEx4GiXvgnU2G45qIBDm5d+82U+Sag+fLdl1/tktnVX7Hn6rJHGWUme/91wObvQRIV52CmV2+G3e49hR5DkNN7+yd/aL6fBTmT5wLKyabI2wf3birmlRScYtKT7uhi4pbBbolDJKubizegJB/48VhKHj6s4XujTCycorE9ucHLbgaAEDQID3inMvHy/fCH0PucAsToae+Yu+MmbSqqsu/899M2jzckCB42oWwseaFmKfGWTdrIwWkz5Bjp73f9dpcD25zo3q9gIFrbuyv2+XJMkQj2OLpTXXK84RW13YsMD8DmrEQya9rFhJsnN8uujoRBk4L9yCYy/PqfST9DV56vQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ deploy:
 # GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in Travis-CI
 # https://travis-ci.org/gettyimages/gettyimages-api_java/settings
 # It must be enabled for the branch you're working on.
-  api_key: 
-    secure: GITHUB_PERSONAL_ACCESS_TOKEN
+  api_key: GITHUB_PERSONAL_ACCESS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: java
 jdk: # jdk versions to test against - https://www.deps.co/guides/travis-ci-latest-java/
-- openjdk8 # oldest version we support. Do not use Oracle because the license expires.
-- openjdk11 # most recent version supported by Travis
+     # Open JDK support: https://adoptopenjdk.net/support.html
+- openjdk8 # LTS through at least 2023.09
+- openjdk11 # LTS through at least 2022.09
 - openjdk-ea # early release - allow failures, but be aware that there *are* errors
 
 matrix:
   allow_failures: # https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail
     - jdk: openjdk-ea # allow early access version to fail
+    
+before_install:
+  ## export GPG details
+  - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+  - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
+
+install:
+  mvn --settings .maven.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
+
+script:
+  ## Build and release to maven central
+  mvn clean deploy --settings .maven.xml -DskipTests=true -B -U -prepare_release
 
 before_deploy:
   # Begin Extract the project version
@@ -31,6 +44,7 @@ deploy:
 
 # GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in Travis-CI
 # https://travis-ci.org/gettyimages/gettyimages-api_java/settings
+# https://stackoverflow.com/questions/33735992/travis-ci-using-repository-environment-variables-in-travis-yml
 # It must be enabled for the branch you're working on.
   #api_key: GITHUB_PERSONAL_ACCESS_TOKEN
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,6 @@ deploy:
 # GITHUB_PERSONAL_ACCESS_TOKEN is an environment variable set in Travis-CI
 # https://travis-ci.org/gettyimages/gettyimages-api_java/settings
 # It must be enabled for the branch you're working on.
-  api_key: GITHUB_PERSONAL_ACCESS_TOKEN
+  #api_key: GITHUB_PERSONAL_ACCESS_TOKEN
+  api_key:
+    secure: pJkTcxWJUO0eJK6fH5D7Vb3BEQoc9tnKGX5pTa7n6OCqJU3qQHJVVpAphoCW5BfYQl1A7svNYGNZh7l/quzznxhBLS1HoV78AJcM4PnL1L/WuSgSIHDwOUZpZ1xctqMcZFh1+oavR4tRTk/mvcjBmUrcR1nOgctdx19i5/FzN7AlVwQZDZi80pd1Q/XnK0ID71GDQ0Zrb0w3Txi4/xHgsDbkN6By0wdCKd3slnYX6Bdd3zLSSGYmqdWWHMUgWrU8yMXwAP5G0lgksNBKv71JxBx6ZJE0QOeqvbIeIn9zLbRxHQKgbw9gJBeXHmlQBcbE+yJ5SqAfuPguSWQRs9PbCEx4GiXvgnU2G45qIBDm5d+82U+Sag+fLdl1/tktnVX7Hn6rJHGWUme/91wObvQRIV52CmV2+G3e49hR5DkNN7+yd/aL6fBTmT5wLKyabI2wf3birmlRScYtKT7uhi4pbBbolDJKubizegJB/48VhKHj6s4XujTCycorE9ucHLbgaAEDQID3inMvHy/fCH0PucAsToae+Yu+MmbSqqsu/899M2jzckCB42oWwseaFmKfGWTdrIwWkz5Bjp73f9dpcD25zo3q9gIFrbuyv2+XJMkQj2OLpTXXK84RW13YsMD8DmrEQya9rFhJsnN8uujoRBk4L9yCYy/PqfST9DV56vQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
     secure: QRDWEzr7ecy99uFYetCl6v0t1QSJKfAUJcMPxWQJNWohmzO1oxA7SJF+1PUqyj8cgP+ykZDrqdI3jHZCU+YPOtXirxDkxItc/uMsfJBQAaMlDLzIiZpx6husPAzvatp7xDC/KSRKfQlTv7NnP9oLt/hn8phTxHGyIssV6Xnpd/e84Uqu55NxyeuIfuTeEoVzuC8o4c5NpAClYASwgHV4l8e8uTDQqITx2Y/qbsukh/bq0TYLAQZkHf9GzhJ9Kfqo6p4vMybzn9bGUptf1c/gIUb/OckBTDC4yka3xHdTWvk+nlKPTPrO4LEeIrJ2JbT46ljBqaRzXmAEjr7A2l2rJd3xMOgD09Cb1Od+xiQ900hrh2o/0oSjcChRLZbRe/ztpe5SmJuyJcesBMM+wlvwwNE6hVc77BBCKvzen88OXHzgB8VX3ymKgz6adFKgNI614nemLcNP8/UyqqnjMf5rfknTp9rOkIxmmt9LNSapABCs2IJRlx5zQBup6ij3S66TL5JogEHsVxEzm1zn3vFOx2FJA+tRbd414eP0iB87Zi9tzI9z2/ZBkHTEUXnn22Y0w6W2fPJznTJ4NyJGMmgNLVvpmq0sl9KpfGp4rkof/kADhfxTIjUjRzc1UDHkiJHzxG/Tbw1Ojo+rQnj1RsestQ586tVvGOg0zhiapikGCOE=
   file: gettyimagesapi-sdk/target/gettyimagesapi-sdk-$project_version.jar
   on:
-    tags: true
+    #tags: true
     repo: gettyimages/gettyimages-api_java
     # TODO remove the branch after you're done testing
     branch: deploy

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -35,10 +35,10 @@
     </scm>
 
     <distributionManagement>
-        <snapshotrepository>
+        <snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotrepository>
+        </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>
@@ -122,7 +122,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -34,12 +34,7 @@
         <url>https://github.com/gettyimages/gettyimages-api_java</url>
     </scm>
 
-    <distributionmanagement>
-        <site>
-            <id>api.wiki</id>
-            <url>https://github.com/phillip-kruger/apiee/wiki</url>
-        </site>
-
+    <distributionManagement>
         <snapshotrepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
@@ -48,8 +43,7 @@
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
-
-    </distributionmanagement>
+    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>
@@ -33,6 +33,23 @@
     <scm>
         <url>https://github.com/gettyimages/gettyimages-api_java</url>
     </scm>
+
+    <distributionmanagement>
+        <site>
+            <id>api.wiki</id>
+            <url>https://github.com/phillip-kruger/apiee/wiki</url>
+        </site>
+
+        <snapshotrepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotrepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+
+    </distributionmanagement>
 
     <dependencies>
         <dependency>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi-sdk</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.0</version>
     <name>gettyimagesapi-sdk</name>
     <description>A SDK for Getty Images API</description>
     <url>http://api.gettyimages.com</url>

--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -117,7 +117,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -128,7 +128,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -141,7 +141,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>2.10.4</version>
+                        <configuration>
+                        <source>8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -154,7 +157,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,4 +17,15 @@
     <modules>
         <module>gettyimagesapi-sdk</module>
     </modules>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.0</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gettyimages</groupId>
     <artifactId>gettyimagesapi</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <packaging>pom</packaging>
 
     <name>gettyimagesapi</name>


### PR DESCRIPTION
These changes automate the build process for the Java SDK. There are two small tweaks that need to be made before this is released, but otherwise this should be ready to review.

This automates the manual process described on the _Releasing Java SDK_ page of the internal Wiki.

Only tagged builds will be released to the Nexus staging repository.

The changes adhere pretty closely to those in [this article](https://www.phillip-kruger.com/post/continuous_integration_to_maven_central/).

Some additional information is available in these Sonatype articles:

- [PGP Signatures](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
- [Maven Central deployment](https://central.sonatype.org/pages/apache-maven.html)
- [Deleting from Nexus](https://support.sonatype.com/hc/en-us/articles/213465308-Can-I-delete-releases-from-Nexus-after-they-have-been-published-)