### PR TITLE
Added missing test scopes

### DIFF
--- a/gettyimagesapi-sdk/pom.xml
+++ b/gettyimagesapi-sdk/pom.xml
@@ -72,11 +72,13 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <version>3.10.8</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
             <version>3.10.8</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
If the test dependencies don't have the 'test' scope, the tests of projects that include this api as dependency will break.