### PR TITLE
Add an option to override autoDownlod property

### DIFF
--- a/src/main/java/com/gettyimages/api/Downloads/DownloadImages.java
+++ b/src/main/java/com/gettyimages/api/Downloads/DownloadImages.java
@@ -29,7 +29,7 @@ public class DownloadImages extends AbstractApiRequest {
             throw new SdkException(MustSpecifyAtLeastOneImageIdMessage);
         }
 
-        queryParams.put(Constants.AutoDownloadParameterName, false);
+        queryParams.putIfAbsent(Constants.AutoDownloadParameterName, true);
 
         method = "POST";
         path = DownloadsPathString + assetId;
@@ -70,6 +70,12 @@ public class DownloadImages extends AbstractApiRequest {
     public DownloadImages withProductType(ProductType value)
     {
         queryParams.put(Constants.ProductTypeParameterName, value);
+        return this;
+    }
+
+    public DownloadImages withAutoDownload(Boolean autoDownload)
+    {
+        queryParams.put(Constants.AutoDownloadParameterName, autoDownload);
         return this;
     }
 }

--- a/src/test/java/DownloadImagesTest.java
+++ b/src/test/java/DownloadImagesTest.java
@@ -6,7 +6,6 @@ import com.gettyimages.api.Filters.FileType;
 import com.gettyimages.api.Filters.ProductType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
@@ -44,7 +43,7 @@ public class DownloadImagesTest {
                                 .withMethod("POST")
                                 .withPath("/downloads/images/12345")
                                 .withQueryStringParameters(
-                                        new Parameter("auto_download", "false")
+                                        new Parameter("auto_download", "true")
                                 )
                                 .withHeader("Accept-Language", "de")
                 )
@@ -55,7 +54,7 @@ public class DownloadImagesTest {
                                 .withPath("/downloads/images/12345")
                                 .withQueryStringParameters(
                                         new Parameter("file_type", "jpg"),
-                                        new Parameter("auto_download", "false")
+                                        new Parameter("auto_download", "true")
                                 )
                 )
                 .respond(response().withStatusCode(200).withBody("success"));
@@ -64,7 +63,7 @@ public class DownloadImagesTest {
                                 .withMethod("POST")
                                 .withPath("/downloads/images/12345")
                                 .withQueryStringParameters(
-                                        new Parameter("auto_download", "false"),
+                                        new Parameter("auto_download", "true"),
                                         new Parameter("height", "592")
                                 )
                 )
@@ -75,7 +74,7 @@ public class DownloadImagesTest {
                                 .withPath("/downloads/images/12345")
                                 .withQueryStringParameters(
                                         new Parameter("product_id", "9876"),
-                                        new Parameter("auto_download", "false")
+                                        new Parameter("auto_download", "true")
                                 )
                 )
                 .respond(response().withStatusCode(200).withBody("success"));
@@ -85,6 +84,15 @@ public class DownloadImagesTest {
                                 .withPath("/downloads/images/12345")
                                 .withQueryStringParameters(
                                         new Parameter("product_type", "easyaccess"),
+                                        new Parameter("auto_download", "true")
+                                )
+                )
+                .respond(response().withStatusCode(200).withBody("success"));
+        client.when(
+                        request()
+                                .withMethod("POST")
+                                .withPath("/downloads/images/12345")
+                                .withQueryStringParameters(
                                         new Parameter("auto_download", "false")
                                 )
                 )
@@ -133,6 +141,15 @@ public class DownloadImagesTest {
         ApiClient client = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret");
         DownloadImages downloadimages = client.downloadimages()
                 .withId("12345").withProductType(ProductType.EASYACCESS);
+        String result = downloadimages.executeAsync();
+        assertEquals("success", result);
+    }
+
+    @Test
+    void downloadImagesWithDisabledAutoDownload() throws Exception {
+        ApiClient client = ApiClient.GetApiClientWithClientCredentials("apiKey", "apiSecret");
+        DownloadImages downloadimages = client.downloadimages()
+                .withId("12345").withAutoDownload(false);
         String result = downloadimages.executeAsync();
         assertEquals("success", result);
     }


### PR DESCRIPTION
Additionally, the default value for `autoDownload` was changed to `true` to be consistent with the documentation.

https://api.gettyimages.com/swagger/index.html#/Downloads/post_v3_downloads_images__id_

Solves: https://github.com/gettyimages/gettyimages-api_java/issues/19