### PR TITLE
Credentials concerns

### DIFF
--- a/src/main/java/com/gettyimages/api/Credentials.java
+++ b/src/main/java/com/gettyimages/api/Credentials.java
@@ -74,9 +74,22 @@ public class Credentials {
     }
 
     public Token GetAccessToken() throws SdkException {
+
+        // "now" seems like a bad name.  The value is set to some time into the future to then
+        // compare to the token expiration.  If the token expiration is equal to or after this 
+        // time then we keep caching.
         Calendar now = Calendar.getInstance();
         now.add(Calendar.MINUTE, 5);
 
+        // Bug?  This reads to me like we'll never cache the token.
+        // It only returns the cached token if the CredentialType is all at once NOT: 
+        // - ClientCredentials
+        // - ResourceOwner
+        // - RefreshToken
+        // First, this doesn't seem right: you'd want to cache the token in the case of CC or RO, right?
+        // Second, we don't offer any way to instantiate Credentials *except* for these cases.
+        // That tells me we're never caching the token.
+        // Keep caching as long as the token's expiration is equal to or after 5 minutes from now
         if (CredentialType != CredentialType.ClientCredentials && CredentialType != CredentialType.ResourceOwner && CredentialType != CredentialType.RefreshToken
                 ||
                 (accessToken != null && accessToken.getExpiration().compareTo(now.getTime()) >= 0)) {


### PR DESCRIPTION
I don't think there's any logical issue with `now` and the token expiration (although I take issue with the name of the variable).  I read this as the condition will hold true and keep caching the token until the token expiration is _less_ than 5 minutes away.  Exactly what we want.

The larger issue I see is that I don't think we're actually _ever_ caching the token because of the `CredentialType` conditions.  There's a little more information in my inline comments.

Let me know what you think here, @ssterli2 and @mapitman