### PR TITLE
ApiClient and Credentials "help"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ ApiClient client = ApiClient.GetApiClientWithClientCredentials(apiKey, apiSecret
 ```
 
 For more examples, see unittests package.
+
+## `ApiClient` lifecycle
+
+In production applications, we recommend utilizing the `ApiClient` as a global singleton.  This ensures that token caching is properly performed.

--- a/src/main/java/com/gettyimages/api/Credentials.java
+++ b/src/main/java/com/gettyimages/api/Credentials.java
@@ -74,12 +74,12 @@ public class Credentials {
     }
 
     public Token GetAccessToken() throws SdkException {
-        Calendar now = Calendar.getInstance();
-        now.add(Calendar.MINUTE, 5);
+        Calendar expirationCushion = Calendar.getInstance();
+        expirationCushion.add(Calendar.MINUTE, 5);
 
         if (CredentialType != CredentialType.ClientCredentials && CredentialType != CredentialType.ResourceOwner && CredentialType != CredentialType.RefreshToken
                 ||
-                (accessToken != null && accessToken.getExpiration().compareTo(now.getTime()) >= 0)) {
+                (accessToken != null && accessToken.getExpiration().compareTo(expirationCushion.getTime()) >= 0)) {
             return accessToken;
         }
 


### PR DESCRIPTION
- Try to make the token expiration logic a little more clear
- Communicate in README that `ApiClient` should be a global singleton for production apps